### PR TITLE
add cinoptions to indent anonymous classes and Map/List declarations correctly

### DIFF
--- a/syntax/dart.vim
+++ b/syntax/dart.vim
@@ -117,3 +117,4 @@ set expandtab
 set shiftwidth=2
 set softtabstop=2
 set cindent
+set cinoptions+=j1,J1


### PR DESCRIPTION
From [:help cindent](https://github.com/rgruener/.vim/blob/master/doc/indent.txt)

jN    Indent Java anonymous classes correctly.  Also works well for
Javascript.  The value 'N' is currently unused but must be
non-zero (e.g. 'j1').  'j1' will indent for example the
following code snippet correctly:

```
object.add(new ChangeListener() {
  public void stateChanged(ChangeEvent e) {
    do_something();
  }
});
```

JN    Indent JavaScript object declarations correctly by not confusing
them with labels.  The value 'N' is currently unused but must be 
non-zero (e.g. 'J1').  If you enable this you probably also want
to set |cino-j|.

```
var bar = {
  foo: {
    that: this,
    some: ok,
  },
  "bar":{ 
    a : 2,
    b: "123abc",
    x: 4,
    "y": 5
  }
}
```
