### PR TITLE
Disable plugin indentation settings

### DIFF
--- a/ftplugin/dart.vim
+++ b/ftplugin/dart.vim
@@ -3,18 +3,11 @@ if exists('b:did_ftplugin')
 endif
 let b:did_ftplugin = 1
 
-<<<<<<< HEAD
 " Enable automatic indentation (2 spaces) if variable g:dart_style_guide is set 
 if exists('g:dart_style_guide')
   setlocal expandtab
   setlocal shiftwidth=2
   setlocal softtabstop=2
-=======
-" Enable automatic indentation (2 spaces)
-"setlocal expandtab
-"setlocal shiftwidth=2
-"setlocal softtabstop=2
->>>>>>> 4cabcf507db3832ad4432f7c034e6f64b9010f02
 
   setlocal formatoptions-=t
 endif


### PR DESCRIPTION
I think it should be on user if he wants to use Dart coding style or not. Overriding user's editor behaviour isn't good practice.

If someone wants to use Dart coding style, he can set it up everytime.
