### PR TITLE
Tweak indentation after annotation and inside List

### DIFF
--- a/indent/dart.vim
+++ b/indent/dart.vim
@@ -22,12 +22,12 @@ function! DartIndent()
   let currentLine = getline(v:lnum)
 
   " Don't indent after an annotation
-  if previousLine =~ '^\s*@.*$'
+  if previousLine =~# '^\s*@.*$'
     let indentTo = indent(v:lnum - 1)
   endif
 
   " Indent after opening List literal
-  if previousLine =~ '\[$' && !(currentLine =~ '^\s*\]')
+  if previousLine =~# '\[$' && !(currentLine =~# '^\s*\]')
     let indentTo = indent(v:lnum - 1) + &shiftwidth
   endif
 

--- a/indent/dart.vim
+++ b/indent/dart.vim
@@ -6,4 +6,30 @@ let b:did_indent = 1
 setlocal cindent
 setlocal cinoptions+=j1,J1
 
+setlocal indentexpr=DartIndent()
+
 let b:undo_indent = 'setl cin< cino<'
+
+if exists("*DartIndent")
+  finish
+endif
+
+function! DartIndent()
+  " Default to cindent in most cases
+  let indentTo = cindent(v:lnum)
+
+  let previousLine = getline(prevnonblank(v:lnum - 1))
+  let currentLine = getline(v:lnum)
+
+  " Don't indent after an annotation
+  if previousLine =~ '^\s*@.*$'
+    let indentTo = indent(v:lnum - 1)
+  endif
+
+  " Indent after opening List literal
+  if previousLine =~ '\[$' && !(currentLine =~ '^\s*\]')
+    let indentTo = indent(v:lnum - 1) + &shiftwidth
+  endif
+
+  return indentTo
+endfunction


### PR DESCRIPTION
Final indentation should be handled by dartfmt, but having vim behave
slightly closer to dartfmt while editing gives a less annoying
experience.

- Add a DartIndent function to handle edge cases not covered by cindent
- Check whether previous line starts with '@' and don't indent
- Check wither previous line opens a List literal and indent