### PR TITLE
Support gf for package: uris when .packages exists

### DIFF
--- a/autoload/dart.vim
+++ b/autoload/dart.vim
@@ -66,3 +66,71 @@ function! dart#tojs(q_args) abort
   endif
 endfunction
 
+" Finds the path to `uri`.
+"
+" If the file is a package: uri, looks for a .packages file to resolve the path.
+" If the path cannot be resolved, or is not a package: uri, returns the
+" original.
+function! dart#resolveUri(uri) abort
+  if a:uri !~ 'package:'
+    return a:uri
+  endif
+  let package_name = substitute(a:uri, 'package:\(\w\+\)\/.*', '\1', '')
+  let [found, package_map] = s:PackageMap()
+  if !found
+    call s:error('cannot find .packages file')
+    return a:uri
+  endif
+  if !has_key(package_map, package_name)
+    call s:error('no package mapping for '.package_name)
+    return a:uri
+  endif
+  let package_lib = package_map[package_name]
+  return substitute(a:uri, 'package:'.package_name, package_map[package_name], '')
+endfunction
+
+" A map from package name to lib directory parse from a '.packages' file.
+"
+" Returns [found, package_map]
+function! s:PackageMap() abort
+  let [found, dot_packages] = s:DotPackagesFile()
+  if !found
+    return [v:false, {}]
+  endif
+  let dot_packages_dir = fnamemodify(dot_packages, ':p:h')
+  let lines = readfile(dot_packages)
+  let map = {}
+  for line in lines
+    if line =~ '\s*#'
+      continue
+    endif
+    let package = substitute(line, ':.*$', '', '')
+    let lib_dir = substitute(line, '^[^:]*:', '', '')
+    if lib_dir =~ 'file:/'
+      let lib_dir = substitute(resolve(lib_dir), 'file:', '', '')
+    else
+      let lib_dir = resolve(dot_packages_dir.'/'.lib_dir)
+    endif
+    let map[package] = lib_dir
+  endfor
+  return [v:true, map]
+endfunction
+
+" Finds a file name '.packages' in the cwd, or in any directory above the open
+" file.
+"
+" Returns [found, file].
+function! s:DotPackagesFile() abort
+  if filereadable('.packages')
+    return [v:true, '.packages']
+  endif
+  let dir_path = expand('%:p:h')
+  while dir_path != '/'
+    let file_path = dir_path.'/.packages'
+    if filereadable(file_path)
+      return [v:true, file_path]
+    endif
+    let dir_path = fnamemodify(dir_path, ':h')
+  endwhile
+  return [v:false, '']
+endfunction

--- a/autoload/dart.vim
+++ b/autoload/dart.vim
@@ -86,7 +86,10 @@ function! dart#resolveUri(uri) abort
     return a:uri
   endif
   let package_lib = package_map[package_name]
-  return substitute(a:uri, 'package:'.package_name, package_map[package_name], '')
+  return substitute(a:uri,
+      \ 'package:'.package_name,
+      \ escape(package_map[package_name], '\'),
+      \ '')
 endfunction
 
 " A map from package name to lib directory parse from a '.packages' file.

--- a/autoload/dart.vim
+++ b/autoload/dart.vim
@@ -134,12 +134,16 @@ function! s:DotPackagesFile() abort
     return [v:true, '.packages']
   endif
   let dir_path = expand('%:p:h')
-  while dir_path != '/'
+  while v:true
     let file_path = dir_path.'/.packages'
     if filereadable(file_path)
       return [v:true, file_path]
     endif
-    let dir_path = fnamemodify(dir_path, ':h')
+    let parent = fnamemodify(dir_path, ':h')
+    if dir_path == parent
+      break
+    endif
+    let dir_path = parent
   endwhile
   return [v:false, '']
 endfunction

--- a/autoload/dart.vim
+++ b/autoload/dart.vim
@@ -107,9 +107,15 @@ function! s:PackageMap() abort
     let package = substitute(line, ':.*$', '', '')
     let lib_dir = substitute(line, '^[^:]*:', '', '')
     if lib_dir =~ 'file:/'
-      let lib_dir = substitute(resolve(lib_dir), 'file:', '', '')
+      let lib_dir = substitute(lib_dir, 'file://', '', '')
+      if lib_dir =~ '/[A-Z]:/'
+        let lib_dir = lib_dir[1:]
+      endif
     else
       let lib_dir = resolve(dot_packages_dir.'/'.lib_dir)
+    endif
+    if lib_dir =~ '/$'
+      let lib_dir = lib_dir[:len(lib_dir) - 2]
     endif
     let map[package] = lib_dir
   endfor

--- a/ftplugin/dart.vim
+++ b/ftplugin/dart.vim
@@ -23,5 +23,7 @@ let &l:errorformat =
   \   '%m'
   \ ], ',')
 
+setlocal includeexpr=dart#resolveUri(v:fname)
+setlocal isfname+=:
 
-let b:undo_ftplugin = 'setl et< fo< sw< sts< com< cms<'
+let b:undo_ftplugin = 'setl et< fo< sw< sts< com< cms< inex< isf<'


### PR DESCRIPTION
Add an includeexpr to a function that can parse .packages file and
resolve the absolute file path to a package: uri. If fname does not
include 'package:' it is returned directly so relative paths still work
as before.

Finds and parses the .packages file on every call. This is fast enough
that caching (and therefore needing to invalidate) the map is probably
not worthwhile.