### PR TITLE
Specify pathogen.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ private directories
         git clone https://github.com/dart-lang/dart-vim-plugin
 
 
-3. Put following codes in your `~/.vimrc`.
+3. Put following codes in your `~/.vimrc` under your `execute pathogen#infect()`.
 
         if has('vim_starting')
           set nocompatible


### PR DESCRIPTION
As someone who has never used Pathogen, although it was clear to see I needed Pathogen, I was not sure how to tie them together.  I think this change makes it more clear and should get users up and running with less confusion.