### PR TITLE
Allow formatting without impacting changelist

### DIFF
--- a/autoload/dart.vim
+++ b/autoload/dart.vim
@@ -22,9 +22,11 @@ function! dart#fmt(q_args) abort
     let joined_lines = system(printf('dartfmt %s', a:q_args), buffer_content)
     if 0 == v:shell_error
       let win_view = winsaveview()
-      silent % delete _
-      silent put=joined_lines
-      silent 1 delete _
+      let lines = split(joined_lines, "\n")
+      silent keepjumps call setline(1, lines)
+      if line('$') > len(lines)
+        silent keepjumps execute string(len(lines)+1).',$ delete'
+      endif
       call winrestview(win_view)
     else
       let errors = split(joined_lines, "\n")[2:]


### PR DESCRIPTION
- Using `setline` instead of `delete` and `put` lets marks like the
  changelist survive the edit without being invalidated and won't
  cause other windows showing the buffer to jump.
- keepjumps prevents the edit from adding a changelist entry at the
  beginning of the file.