### PR TITLE
Add `oneline` to dartString highlighting

### DIFF
--- a/syntax/dart.vim
+++ b/syntax/dart.vim
@@ -59,8 +59,8 @@ if exists('dart_html_in_strings') && dart_html_in_strings
   syntax cluster dartRawStringContains add=@HTML
 endif
 syntax cluster dartStringContains contains=@dartRawStringContains,dartInterpolation,dartSpecialChar
-syntax region  dartString        start=+\z(["']\)+ end=+\z1+ contains=@dartStringContains
-syntax region  dartRawString     start=+r\z(["']\)+ end=+\z1+ contains=@dartRawStringContains
+syntax region  dartString         oneline start=+\z(["']\)+ end=+\z1+ contains=@dartStringContains
+syntax region  dartRawString      oneline start=+r\z(["']\)+ end=+\z1+ contains=@dartRawStringContains
 syntax region  dartMultilineString     start=+\z("\{3\}\|'\{3\}\)+ end=+\z1+ contains=@dartStringContains
 syntax region  dartRawMultilineString     start=+r\z("\{3\}\|'\{3\}\)+ end=+\z1+ contains=@dartSRawtringContains
 syntax match   dartInterpolation contained "\$\(\w\+\|{[^}]\+}\)"


### PR DESCRIPTION
Prevents a missing quote from changing highlighting through the rest of
the file - less disruptive in the middle of a change.