### PR TITLE
Highlight the native keyword

### DIFF
--- a/syntax/dart.vim
+++ b/syntax/dart.vim
@@ -33,7 +33,7 @@ syntax keyword dartExceptions     throw rethrow try on catch finally
 syntax keyword dartAssert         assert
 syntax keyword dartClassDecl      extends with implements
 syntax keyword dartBranch         break continue nextgroup=dartUserLabelRef skipwhite
-syntax keyword dartKeyword        get set operator call external async await yield sync
+syntax keyword dartKeyword        get set operator call external async await yield sync native
 syntax match   dartUserLabelRef   "\k\+" contained
 
 syntax region  dartLabelRegion   transparent matchgroup=dartLabel start="\<case\>" matchgroup=NONE end=":"


### PR DESCRIPTION
Note that the 'native' keyword is not part of the Dart Language
Specification. It is, however, used by Dart core library developers and
those using the Dart VM embedding API in order to implement dart:
extension libraries (e.g., Flutter).