### PR TITLE
Add covariant keyword

### DIFF
--- a/syntax/dart.vim
+++ b/syntax/dart.vim
@@ -26,7 +26,7 @@ syntax keyword dartConstant       null
 syntax keyword dartTypedef        this super class typedef enum
 syntax keyword dartOperator       new is as in
 syntax match   dartOperator       "+=\=\|-=\=\|*=\=\|/=\=\|%=\=\|\~/=\=\|<<=\=\|>>=\=\|[<>]=\=\|===\=\|\!==\=\|&=\=\|\^=\=\||=\=\|||\|&&\|\[\]=\=\|=>\|!\|\~\|?\|:"
-syntax keyword dartType           void var bool int double num dynamic
+syntax keyword dartType           void var bool int double num dynamic covariant
 syntax keyword dartStatement      return
 syntax keyword dartStorageClass   static abstract final const factory
 syntax keyword dartExceptions     throw rethrow try on catch finally


### PR DESCRIPTION
Adds syntax highlighting for the 'covariant' keyword, which can be used
in formal parameter lists and on non-final fields.