### PR TITLE
Prevent writes to files in the pub cache

### DIFF
--- a/autoload/dart.vim
+++ b/autoload/dart.vim
@@ -149,3 +149,12 @@ function! s:DotPackagesFile() abort
   endwhile
   return [v:false, '']
 endfunction
+
+" Prevent writes to files in the pub cache.
+function! dart#setModifiable() abort
+  let full_path = expand('%:p')
+  if full_path =~# '.pub-cache'
+      \ full_path =~# 'Pub\Cache'
+    set nomodifiable
+  endif
+endfunction

--- a/autoload/dart.vim
+++ b/autoload/dart.vim
@@ -153,8 +153,8 @@ endfunction
 " Prevent writes to files in the pub cache.
 function! dart#setModifiable() abort
   let full_path = expand('%:p')
-  if full_path =~# '.pub-cache'
+  if full_path =~# '.pub-cache' ||
       \ full_path =~# 'Pub\Cache'
-    set nomodifiable
+    setlocal nomodifiable
   endif
 endfunction

--- a/plugin/dart.vim
+++ b/plugin/dart.vim
@@ -12,6 +12,7 @@ augroup dart-vim-plugin
   autocmd FileType dart command! -buffer -nargs=? DartFmt       call dart#fmt(<q-args>)
   autocmd FileType dart command! -buffer -nargs=? Dart2Js       call dart#tojs(<q-args>)
   autocmd FileType dart command! -buffer -nargs=? DartAnalyzer  call dart#analyzer(<q-args>)
+  autocmd Filetype dart call dart#setModifiable()
 augroup END
 
 let &cpo = s:save_cpo


### PR DESCRIPTION
Dart doesn't expose capabilities to set file permissions so files
downloaded by pub are not readonly. After opening a file, if it's in the
pub cache set `nomodifiable` to prevent accidental edits.