### PR TITLE
Avoid changes if the buffer is already formatted

### DIFF
--- a/autoload/dart.vim
+++ b/autoload/dart.vim
@@ -20,6 +20,7 @@ function! dart#fmt(q_args) abort
   if executable('dartfmt')
     let buffer_content = join(getline(1, '$'), "\n")
     let joined_lines = system(printf('dartfmt %s', a:q_args), buffer_content)
+    if buffer_content ==# joined_lines[:-2] | return | endif
     if 0 == v:shell_error
       let win_view = winsaveview()
       let lines = split(joined_lines, "\n")


### PR DESCRIPTION
Prevents vim from thinking the file is modified and needs to be saved
after a format which doesn't change anything.

The `[:-2]` is because the `dartfmt` output includes a trailing newline
while the `join` omits it.