### PR TITLE
Add some indent options to get closer to dartfmt

### DIFF
--- a/indent/dart.vim
+++ b/indent/dart.vim
@@ -4,7 +4,7 @@ endif
 let b:did_indent = 1
 
 setlocal cindent
-setlocal cinoptions+=j1,J1
+setlocal cinoptions+=j1,J1,(2s,u2s,U1,m1,+2s
 
 setlocal indentexpr=DartIndent()
 


### PR DESCRIPTION
Closes #68

- `m1` - When a closing paren is on a new line, line it up with the
  first character of the line with the opening paren.
- `(2s` - The default, but including it for clarity against the other
  paren indent option.
- `u2s` - When nesting in parents gets deeper than 1, indent by
  2*shiftwidth instead of just shiftwidth. Makes the first and
  subsequent levels of nesting consistent.
- `U1` - Honor nesting levels regarless of whether the opening parent
  for the next level of nesting starts a line - dartfmt tends to put
  nested opening parens on new lines.
- +2s - Use 2 * shiftwidth for expressions broken across lines instead
  of shiftwidth.

Note that the indentation behavior of argument lists varies in dartfmt.
It behaves like `(s` when there is a trailing comma, and `(2s` when
there isn't. Vim indentation can't make a distinction and doing so in
our indent function would be tricky. Since this indentation applies in
more than just argument lists - like long conditionals or asserts, we
get better consistency using `(2s` and letting dartfmt move things back
2 spaces for argument lists with trailing commas.