### PR TITLE
Add an FAQ entry for using Dart analysis server

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ indentation for [Dart][] code in Vim.
 Looking for auto-complete, diagnostics as you type, jump to definition and other
 intellisense features? Try a vim plugin for the
 [Language Server Protocol](http://langserver.org/) such as [vim-lsc][]
-configured to star the Dart analysis server with the `--lsp` flag.
+configured to start the Dart analysis server with the `--lsp` flag.
 
 Looking for an IDE experience? See the [Dart Tools][] page.
 
@@ -109,10 +109,11 @@ server must be run from a snapshot which is shipped in the SDK. The full
 command, assuming the `bin` directory of the SDK is at `$DART_SDK` is
 `$DART_SDK/dart $DART_SDK/snapshots/analysis_server.dart.snapshot --lsp`. If
 you'll be opening files outside of the `rootUri` for the project you may want to
-pass `onlyAnalyzeProjetsWithOpenFiles: true` in the `initializeOptions`. If you
-are using the [vim-lsc][] plugin there is an additional plugin which can configure
-everything for you at [vim-lsc-dart][]. A minimal config for a good default
-experience using [vim-plug][] would look like:
+pass `onlyAnalyzeProjetsWithOpenFiles: true` in the `initializationOptions`. See
+the documentation for your LSP client for how to configure initialization
+options. If you are using the [vim-lsc][] plugin there is an additional plugin
+which can configure everything for you at [vim-lsc-dart][]. A minimal config for
+a good default experience using [vim-plug][] would look like:
 
 ```vimscript
 call plug#begin()

--- a/README.md
+++ b/README.md
@@ -4,14 +4,14 @@ dart-vim-plugin provides filetype detection, syntax highlighting, and
 indentation for [Dart][] code in Vim.
 
 Looking for auto-complete, diagnostics as you type, jump to definition and other
-intellisense features? Try [dart_language_server][] and a vim plugin for the
-[Language Server Protocol](http://langserver.org/) such as [vim-lsc][].
+intellisense features? Try a vim plugin for the
+[Language Server Protocol](http://langserver.org/) such as [vim-lsc][]
+configured to star the Dart analysis server with the `--lsp` flag.
 
 Looking for an IDE experience? See the [Dart Tools][] page.
 
 [Dart]: http://www.dartlang.org/
 [Dart tools]: http://www.dartlang.org/tools/
-[dart_language_server]: https://pub.dartlang.org/packages/dart_language_server
 [vim-lsc]: https://github.com/natebosch/vim-lsc
 
 ## Commands
@@ -100,3 +100,28 @@ in flutter widget code) `dartfmt` uses 2 space indent for argument parameters.
 In all other indentation following an open parenthesis (argument lists without a
 trailing comma, multi-line assert statements, etc) `dartmft` uses 4 space
 indent. This plugin uses 4 space indent to match the most cases.
+
+
+### How do I configure an LSP plugin to start the analysis server?
+
+The Dart SDK comes with an analysis server that can be run in LSP mode. The
+server must be run from a snapshot which is shipped in the SDK. The full
+command, assuming the `bin` directory of the SDK is at `$DART_SDK` is
+`$DART_SDK/dart $DART_SDK/snapshots/analysis_server.dart.snapshot --lsp`. If
+you'll be opening files outside of the `rootUri` for the project you may want to
+pass `onlyAnalyzeProjetsWithOpenFiles: true` in the `initializeOptions`. If you
+are using the [vim-lsc][] plugin there is an additional plugin which can configure
+everything for you at [vim-lsc-dart][]. A minimal config for a good default
+experience using [vim-plug][] would look like:
+
+```vimscript
+call plug#begin()
+Plug 'dart-lang/dart-vim-plugin'
+Plug 'natebosch/vim-lsc'
+Plug 'natebosch/vim-lsc-dart'
+call plug#end()
+
+let g:lsc_auto_map = v:true
+```
+
+[vim-lsc-dart]: https://github.com/natebosch/vim-lsc-dart

--- a/README.md
+++ b/README.md
@@ -105,15 +105,16 @@ indent. This plugin uses 4 space indent to match the most cases.
 ### How do I configure an LSP plugin to start the analysis server?
 
 The Dart SDK comes with an analysis server that can be run in LSP mode. The
-server must be run from a snapshot which is shipped in the SDK. The full
-command, assuming the `bin` directory of the SDK is at `$DART_SDK` is
+server ships with the SDK. Assuming the `bin` directory of the SDK is at
+`$DART_SDK` the full command to run the analysis server in LSP mode is
 `$DART_SDK/dart $DART_SDK/snapshots/analysis_server.dart.snapshot --lsp`. If
-you'll be opening files outside of the `rootUri` for the project you may want to
-pass `onlyAnalyzeProjetsWithOpenFiles: true` in the `initializationOptions`. See
-the documentation for your LSP client for how to configure initialization
-options. If you are using the [vim-lsc][] plugin there is an additional plugin
-which can configure everything for you at [vim-lsc-dart][]. A minimal config for
-a good default experience using [vim-plug][] would look like:
+you'll be opening files outside of the `rootUri` sent by your LSP client
+(usually `cwd`) you may want to pass `onlyAnalyzeProjetsWithOpenFiles: true` in
+the `initializationOptions`. See the documentation for your LSP client for how
+to configure initialization options. If you are using the [vim-lsc][] plugin
+there is an additional plugin which can configure everything for you at
+[vim-lsc-dart][]. A minimal config for a good default experience using
+[vim-plug][] would look like:
 
 ```vimscript
 call plug#begin()


### PR DESCRIPTION
Closes #79

Removes mention of `dart_language_server` since the analysis server is
the supported path expect to use and promote going forward. Adds an FAQ
entry which describes the command that needs to be run to start the
analysis server since it's not as simple as a single command already on
your `$PATH`. Also points out the option of using a preconfigured plugin
which handles locating the right command for you.