### PR TITLE
Add highlighting for user defined types (#74)

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Disable highlighting of core library classes with `let
 dart_corelib_highlight=v:false` (default true).
 
 Disable highlighting of user defined types (words starting with a capital
-leter) with `let dart_highlight_types=v:false` (default true).
+letter) with `let dart_highlight_types=v:false` (default true).
 
 Enable Dart style guide syntax (like 2-space indentation) with `let dart_style_guide = 2`
 

--- a/README.md
+++ b/README.md
@@ -84,6 +84,9 @@ dart_html_in_string=v:true` (default false).
 Disable highlighting of core library classes with `let
 dart_corelib_highlight=v:false` (default true).
 
+Enable highlighting of user defined types with `let
+dart_highlight_types=v:true` (default false).
+
 Enable Dart style guide syntax (like 2-space indentation) with `let dart_style_guide = 2`
 
 Enable DartFmt execution on buffer save with `let dart_format_on_save = 1`

--- a/README.md
+++ b/README.md
@@ -84,8 +84,8 @@ dart_html_in_string=v:true` (default false).
 Disable highlighting of core library classes with `let
 dart_corelib_highlight=v:false` (default true).
 
-Enable highlighting of user defined types with `let
-dart_highlight_types=v:true` (default false).
+Disable highlighting of user defined types (words starting with a capital
+leter) with `let dart_highlight_types=v:false` (default true).
 
 Enable Dart style guide syntax (like 2-space indentation) with `let dart_style_guide = 2`
 

--- a/syntax/dart.vim
+++ b/syntax/dart.vim
@@ -53,7 +53,7 @@ syntax match dartNumber         "\<\d\+\(\.\d\+\)\=\>"
 
 " User Types
 if !exists('dart_highlight_types') || dart_highlight_types
-    syntax match dartTypeName   "\<[A-Z]\w*\>\|\<_[A-Z]\w*\>"
+  syntax match dartTypeName   "\<[A-Z]\w*\>\|\<_[A-Z]\w*\>"
 endif
 
 " Core libraries

--- a/syntax/dart.vim
+++ b/syntax/dart.vim
@@ -51,8 +51,8 @@ syntax match   dartMetadata      "@\([_$a-zA-Z][_$a-zA-Z0-9]*\.\)*[_$a-zA-Z][_$a
 " Numbers
 syntax match dartNumber         "\<\d\+\(\.\d\+\)\=\>"
 
-" Types
-if exists('dart_highlight_types') && dart_highlight_types
+" User Types
+if !exists('dart_highlight_types') || dart_highlight_types
     syntax match dartTypeName   "\<[A-Z]\w*\>\|\<_[A-Z]\w*\>"
 endif
 

--- a/syntax/dart.vim
+++ b/syntax/dart.vim
@@ -51,6 +51,11 @@ syntax match   dartMetadata      "@\([_$a-zA-Z][_$a-zA-Z0-9]*\.\)*[_$a-zA-Z][_$a
 " Numbers
 syntax match dartNumber         "\<\d\+\(\.\d\+\)\=\>"
 
+" Types
+if exists('dart_highlight_types') && dart_highlight_types
+    syntax match dartTypeName   "\<[A-Z]\w*\>\|\<_[A-Z]\w*\>"
+endif
+
 " Core libraries
 if !exists('dart_corelib_highlight') || dart_corelib_highlight
   syntax keyword dartCoreClasses BidirectionalIterator Comparable DateTime
@@ -116,6 +121,7 @@ highlight default link dartTypedef         Typedef
 highlight default link dartTodo            Todo
 highlight default link dartKeyword         Keyword
 highlight default link dartType            Type
+highlight default link dartTypeName        Type
 highlight default link dartInterpolation   PreProc
 highlight default link dartDocLink         SpecialComment
 highlight default link dartSpecialChar     SpecialChar


### PR DESCRIPTION
Hello!

I start to write Flutter with Vim recently. 
I just found out this [issue ](https://github.com/dart-lang/dart-vim-plugin/issues/74)when I want my defined types to be highlighted .

I added highlight options `dart_highlight_types`. default is false.

![image](https://user-images.githubusercontent.com/31115673/64966166-40e89d00-d8d9-11e9-9b33-28eaf2011ee4.png)

Thank you!