### PR TITLE
Add filetype detection for shebang lines

### DIFF
--- a/ftdetect/dart.vim
+++ b/ftdetect/dart.vim
@@ -1,1 +1,10 @@
 autocmd BufRead,BufNewFile *.dart set filetype=dart
+
+function! s:DetectShebang()
+  if did_filetype() | return | endif
+  if getline(1) == '#!/usr/bin/env dart'
+    setlocal filetype=dart
+  endif
+endfunction
+
+autocmd BufRead * call s:DetectShebang()


### PR DESCRIPTION
The `did_filetype()` check will avoid doing any work if the filetype was
chosen somewhere else.

Use only `BufRead` since `BufNewFile` shouldn't have any content.