### PR TITLE
Handle 'Isolate creation failed' in dartfmt

### DIFF
--- a/autoload/dart.vim
+++ b/autoload/dart.vim
@@ -31,6 +31,8 @@ function! dart#fmt(q_args) abort
     let args = '--stdin-name '.expand('%').' '.a:q_args
     let lines = systemlist(printf('dartfmt %s', args),
         \ join(buffer_content, "\n"))
+    " TODO(https://github.com/dart-lang/sdk/issues/38507) - Remove once the
+    " tool no longer emits this line on SDK upgrades.
     if lines[-1] ==# 'Isolate creation failed'
       let lines = lines[:-2]
     endif


### PR DESCRIPTION
The first time `dartfmt` is run after upgrading the Dart SDK the message
'Isolate creation failed' is emitted on stderr. We can't ignore stderr
completely since we also get errors there if the code can't be
formatted.

See https://github.com/dart-lang/sdk/issues/38507

- Use `systemlist` to avoid an extra split of the string to check the
  last line, keep `buffer_content` as a list as well.
- If the last line matches exactly the error message, remove and ignore
  it.