### PR TITLE
Add option to support dartfmt args on save

### DIFF
--- a/plugin/dart.vim
+++ b/plugin/dart.vim
@@ -10,7 +10,8 @@ set cpo&vim
 function! s:FormatOnSave()
   " Dart code formatting on save
   if get(g:, "dart_format_on_save", 0)
-    call dart#fmt("")
+    let args = get(g:, "dart_format_args", "")
+    call dart#fmt(args)
   endif
 endfunction
 


### PR DESCRIPTION
Hi, I added an option to support `dartfmt` when auto formatting during save. This is useful if you need to configure it to a longer line length for example. 