### PR TITLE
Add function highlighting

### DIFF
--- a/syntax/dart.vim
+++ b/syntax/dart.vim
@@ -56,6 +56,9 @@ if !exists('dart_highlight_types') || dart_highlight_types
   syntax match dartTypeName   "\<[A-Z]\w*\>\|\<_[A-Z]\w*\>"
 endif
 
+" Function highlighting
+syntax match  dartFunction      "\zs\<\(_\?\l[[:alnum:]_\$]*\)\>*\s*\ze("
+
 " Core libraries
 if !exists('dart_corelib_highlight') || dart_corelib_highlight
   syntax keyword dartCoreClasses BidirectionalIterator Comparable DateTime
@@ -132,6 +135,7 @@ highlight default link dartCoreClasses     Type
 highlight default link dartCoreTypedefs    Typedef
 highlight default link dartCoreExceptions  Exception
 highlight default link dartMetadata        PreProc
+highlight default link dartFunction        Function
 
 let b:current_syntax = "dart"
 let b:spell_options = "contained"


### PR DESCRIPTION
Personally, I think "keyword" suits `var` better than "type," but if that isn't a welcome change I can remove it.

Also, the default for `g:dart_highlight_functions` is `v:true`; let me know if it should default to `v:false`.

Function highlighting code gotten from [this gist](https://gist.github.com/sgon00/3e6636f7cafcecb7ed88df9169d8229c#file-dart-vim-L1-L2).