### PR TITLE
Allow $ character in type names

### DIFF
--- a/ftplugin/dart.vim
+++ b/ftplugin/dart.vim
@@ -25,5 +25,6 @@ let &l:errorformat =
 
 setlocal includeexpr=dart#resolveUri(v:fname)
 setlocal isfname+=:
+setlocal iskeyword+=$
 
 let b:undo_ftplugin = 'setl et< fo< sw< sts< com< cms< inex< isf<'

--- a/syntax/dart.vim
+++ b/syntax/dart.vim
@@ -53,7 +53,7 @@ syntax match dartNumber         "\<\d\+\(\.\d\+\)\=\>"
 
 " User Types
 if !exists('dart_highlight_types') || dart_highlight_types
-  syntax match dartTypeName   "\<[A-Z]\w*\>\|\<_[A-Z]\w*\>"
+  syntax match dartTypeName   "\<_\?\u[[:alnum:]_\$]*\>"
 endif
 
 " Core libraries


### PR DESCRIPTION
Add `$` as a keyword character since it is allowed in Dart identifiers.
This fixes the behavior of  the `w` word motion as well as allows syntax
groups to match across the character.

Refactor the `dartTypeName` regex. Use an optional `_` at the beginning,
rather than repeating the pattern with an without `_`. Use the `\u`
character class instead of the group `[A-Z]`. Replace the `\w` character
class with a group that includes the same characters and adds `$`.