### PR TITLE
Remove configuration variables for highlights

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,15 +71,13 @@ call vundle#end()
 Enable HTML syntax highlighting inside Dart strings with `let
 dart_html_in_string=v:true` (default false).
 
-Disable highlighting of core library classes with `let
-dart_corelib_highlight=v:false` (default true).
+Highlighting for specific syntax groups can be disabled by defining custom
+highlight group links. See `:help dart-syntax`
 
-Disable highlighting of user defined types (words starting with a capital
-letter) with `let dart_highlight_types=v:false` (default true).
+Enable Dart style guide syntax (like 2-space indentation) with
+`let g:dart_style_guide = 2`
 
-Enable Dart style guide syntax (like 2-space indentation) with `let dart_style_guide = 2`
-
-Enable DartFmt execution on buffer save with `let dart_format_on_save = 1`
+Enable DartFmt execution on buffer save with `let g:dart_format_on_save = 1`
 
 ## FAQ
 

--- a/doc/dart.txt
+++ b/doc/dart.txt
@@ -51,4 +51,31 @@ Set to any value (set to `2` by convention) to set tab and width behavior to
 match the Dart style guide - spaces only with an indent of 2. Also sets
 `formatoptions += t` to auto wrap text.
 
+SYNTAX HIGHLIGHTING                              *dart-syntax*
+
+This plugin uses narrow highlight groups to allow selectively disabling the
+syntax highlights. Link any of the following groups to the `Normal` highlight
+group to disable them:
+
+`dartSdkException`: Capitalized exception or error classes defined in the SDK.
+
+`dartCoreType`: `void`, `var`, `dynamic`
+
+`dartSdkClass`: Capitalized classes defined in the SDK, along with `bool`,
+`int`, `double`, and `num`.
+
+`dartUserType`: Any capitalized identifier.
+
+`dartType`: Combines `dartCoreType`, `dartSdkClass`, and `dartUserType`.
+
+`dartSdkTypedef`: SDK defined `typdef`s.
+
+`dartFunction`: Any lower cased identifier preceding an open parenthesis.
+
+For example, to remove the highlighting for type and function names:
+>
+ highlight link dartType Normal
+ highlight link dartFunction Normal
+<
+
  vim:tw=78:sw=4:ts=8:ft=help:norl:

--- a/syntax/dart.vim
+++ b/syntax/dart.vim
@@ -26,7 +26,7 @@ syntax keyword dartConstant       null
 syntax keyword dartTypedef        this super class typedef enum mixin
 syntax keyword dartOperator       new is as in
 syntax match   dartOperator       "+=\=\|-=\=\|*=\=\|/=\=\|%=\=\|\~/=\=\|<<=\=\|>>=\=\|[<>]=\=\|===\=\|\!==\=\|&=\=\|\^=\=\||=\=\|||\|&&\|\[\]=\=\|=>\|!\|\~\|?\|:"
-syntax keyword dartType           void var bool int double num dynamic
+syntax keyword dartCoreType       void var dynamic
 syntax keyword dartStatement      return
 syntax keyword dartStorageClass   static abstract final const factory
 syntax keyword dartExceptions     throw rethrow try on catch finally
@@ -49,30 +49,26 @@ syntax match   dartLibrary       "^\(library\|part of\|part\)\>"
 syntax match   dartMetadata      "@\([_$a-zA-Z][_$a-zA-Z0-9]*\.\)*[_$a-zA-Z][_$a-zA-Z0-9]*\>"
 
 " Numbers
-syntax match dartNumber         "\<\d\+\(\.\d\+\)\=\>"
+syntax match   dartNumber        "\<\d\+\(\.\d\+\)\=\>"
 
 " User Types
-if !exists('dart_highlight_types') || dart_highlight_types
-  syntax match dartTypeName   "\<_\?\u[[:alnum:]_\$]*\>"
-endif
+syntax match   dartUserType      "\<_\?\u[[:alnum:]_\$]*\>"
 
 " Function highlighting
-syntax match  dartFunction      "\zs\<\(_\?\l[[:alnum:]_\$]*\)\>*\s*\ze("
+syntax match   dartFunction      "\zs\<\(_\?\l[[:alnum:]_\$]*\)\>*\s*\ze("
 
-" Core libraries
-if !exists('dart_corelib_highlight') || dart_corelib_highlight
-  syntax keyword dartCoreClasses BidirectionalIterator Comparable DateTime
-      \ Duration Expando Function Invocation Iterable Iterator List Map Match
-      \ Object Pattern RegExp RuneIterator Runes Set StackTrace Stopwatch String
-      \ StringBuffer StringSink Symbol Type
-  syntax keyword dartCoreTypedefs   Comparator
-  syntax keyword dartCoreExceptions AbstractClassInstantiationError
-      \ ArgumentError AssertionError CastError ConcurrentModificationError
-      \ Error Exception FallThroughError FormatException
-      \ IntegerDivisionByZeroException NoSuchMethodError NullThrownError
-      \ OutOfMemoryError RangeError RuntimeError StackOverflowError StateError
-      \ TypeError UnimplementedError UnsupportedError
-endif
+" SDK libraries
+syntax keyword dartSdkClass     BidirectionalIterator Comparable DateTime
+    \ Duration Expando Function Invocation Iterable Iterator List Map Match
+    \ Object Pattern RegExp RuneIterator Runes Set StackTrace Stopwatch String
+    \ StringBuffer StringSink Symbol Type bool int double num
+syntax keyword dartSdkTypedef   Comparator
+syntax keyword dartSdkException AbstractClassInstantiationError
+    \ ArgumentError AssertionError CastError ConcurrentModificationError
+    \ Error Exception FallThroughError FormatException
+    \ IntegerDivisionByZeroException NoSuchMethodError NullThrownError
+    \ OutOfMemoryError RangeError RuntimeError StackOverflowError StateError
+    \ TypeError UnimplementedError UnsupportedError
 
 " Comments
 syntax keyword dartTodo          contained TODO FIXME XXX
@@ -120,21 +116,22 @@ highlight default link dartLineComment     Comment
 highlight default link dartLineDocComment  Comment
 highlight default link dartShebangLine     Comment
 highlight default link dartConstant        Constant
-highlight default link dartTypedef         Typedef
 highlight default link dartTodo            Todo
 highlight default link dartKeyword         Keyword
-highlight default link dartType            Type
-highlight default link dartTypeName        Type
 highlight default link dartInterpolation   PreProc
 highlight default link dartDocLink         SpecialComment
 highlight default link dartSpecialChar     SpecialChar
 highlight default link dartLibrary         Include
 highlight default link dartUri             String
 highlight default link dartCombinator      Keyword
-highlight default link dartCoreClasses     Type
-highlight default link dartCoreTypedefs    Typedef
-highlight default link dartCoreExceptions  Exception
 highlight default link dartMetadata        PreProc
+highlight default link dartSdkTypedef      Typedef
+highlight default link dartTypedef         Typedef
+highlight default link dartSdkException    Exception
+highlight default link dartSdkClass        dartType
+highlight default link dartCoreType        dartType
+highlight default link dartUserType        dartType
+highlight default link dartType            Type
 highlight default link dartFunction        Function
 
 let b:current_syntax = "dart"


### PR DESCRIPTION
Closes #95

Keep the `dart_html_in_strings` variable since it has behavior that
can't be changed with highlight groups.

Remove the `dart_highlight_types` and `dart_corelib_highlight`
variables. The behavior from setting these can be achieved by linking
specific highlight groups to `Normal`.

Move the lowercase "primitive" type names from `dartCoreType` to
`dartSdkClass` since they fit better alongside `String`. The ones
remaining in `dartCoreType` are still a "type", or at least often used
in a similar way, but have no class definition. When we add `Never` it
will be a `dartCoreType`.

Add a doc section that describes the highlight groups that are most
likely to be configured with an example of how to disable them.

Rename some groups from "core" to "sdk" since they are more broad than
the `dart:core` library. Use singular names for all highlight groups.

Adjust some spacing for better alignment within the syntax file.