### PR TITLE
Add extension to type keywords list

### DIFF
--- a/syntax/dart.vim
+++ b/syntax/dart.vim
@@ -23,7 +23,7 @@ syntax keyword dartConditional    if else switch
 syntax keyword dartRepeat         do while for
 syntax keyword dartBoolean        true false
 syntax keyword dartConstant       null
-syntax keyword dartTypedef        this super class typedef enum mixin
+syntax keyword dartTypedef        this super class typedef enum mixin extension
 syntax keyword dartOperator       new is as in
 syntax match   dartOperator       "+=\=\|-=\=\|*=\=\|/=\=\|%=\=\|\~/=\=\|<<=\=\|>>=\=\|[<>]=\=\|===\=\|\!==\=\|&=\=\|\^=\=\||=\=\|||\|&&\|\[\]=\=\|=>\|!\|\~\|?\|:"
 syntax keyword dartCoreType       void var dynamic


### PR DESCRIPTION
The extension keyword was added in Dart 2.7.
https://dart.dev/guides/language/extension-methods