### PR TITLE
Fix lints from vim-vint

### DIFF
--- a/autoload/dart.vim
+++ b/autoload/dart.vim
@@ -84,7 +84,7 @@ endfunction
 " If the path cannot be resolved, or is not a package: uri, returns the
 " original.
 function! dart#resolveUri(uri) abort
-  if a:uri !~ 'package:'
+  if a:uri !~# 'package:'
     return a:uri
   endif
   let package_name = substitute(a:uri, 'package:\(\w\+\)\/.*', '\1', '')
@@ -116,20 +116,20 @@ function! s:PackageMap() abort
   let lines = readfile(dot_packages)
   let map = {}
   for line in lines
-    if line =~ '\s*#'
+    if line =~# '\s*#'
       continue
     endif
     let package = substitute(line, ':.*$', '', '')
     let lib_dir = substitute(line, '^[^:]*:', '', '')
-    if lib_dir =~ 'file:/'
+    if lib_dir =~# 'file:/'
       let lib_dir = substitute(lib_dir, 'file://', '', '')
-      if lib_dir =~ '/[A-Z]:/'
+      if lib_dir =~# '/[A-Z]:/'
         let lib_dir = lib_dir[1:]
       endif
     else
       let lib_dir = resolve(dot_packages_dir.'/'.lib_dir)
     endif
-    if lib_dir =~ '/$'
+    if lib_dir =~# '/$'
       let lib_dir = lib_dir[:len(lib_dir) - 2]
     endif
     let map[package] = lib_dir
@@ -139,7 +139,7 @@ endfunction
 
 " Toggle whether dartfmt is run on save or not.
 function! dart#ToggleFormatOnSave() abort
-  if get(g:, "dart_format_on_save", 0)
+  if get(g:, 'dart_format_on_save', 0)
     let g:dart_format_on_save = 0
     return
   endif

--- a/ftdetect/dart.vim
+++ b/ftdetect/dart.vim
@@ -1,10 +1,12 @@
-autocmd BufRead,BufNewFile *.dart set filetype=dart
+augroup dart-vim-plugin-ftdetec
+  autocmd!
+  autocmd BufRead,BufNewFile *.dart set filetype=dart
+  autocmd BufRead * call s:DetectShebang()
+augroup END
 
 function! s:DetectShebang()
   if did_filetype() | return | endif
-  if getline(1) == '#!/usr/bin/env dart'
+  if getline(1) ==# '#!/usr/bin/env dart'
     setlocal filetype=dart
   endif
 endfunction
-
-autocmd BufRead * call s:DetectShebang()

--- a/indent/dart.vim
+++ b/indent/dart.vim
@@ -10,7 +10,7 @@ setlocal indentexpr=DartIndent()
 
 let b:undo_indent = 'setl cin< cino<'
 
-if exists("*DartIndent")
+if exists('*DartIndent')
   finish
 endif
 

--- a/plugin/dart.vim
+++ b/plugin/dart.vim
@@ -9,8 +9,8 @@ set cpo&vim
 
 function! s:FormatOnSave()
   " Dart code formatting on save
-  if get(g:, "dart_format_on_save", 0)
-    call dart#fmt("")
+  if get(g:, 'dart_format_on_save', 0)
+    call dart#fmt('')
   endif
 endfunction
 

--- a/syntax/dart.vim
+++ b/syntax/dart.vim
@@ -3,14 +3,14 @@
 " for details. All rights reserved. Use of this source code is governed by a
 " BSD-style license that can be found in the LICENSE file.
 
-if !exists("g:main_syntax")
-  if version < 600
+if !exists('g:main_syntax')
+  if v:version < 600
     syntax clear
-  elseif exists("b:current_syntax")
+  elseif exists('b:current_syntax')
     finish
   endif
   let g:main_syntax = 'dart'
-  syntax region dartFold start="{" end="}" transparent fold
+  syntax region dartFold start='{' end='}' transparent fold
 endif
 
 " Ensure long multiline strings are highlighted.
@@ -134,8 +134,8 @@ highlight default link dartUserType        dartType
 highlight default link dartType            Type
 highlight default link dartFunction        Function
 
-let b:current_syntax = "dart"
-let b:spell_options = "contained"
+let b:current_syntax = 'dart'
+let b:spell_options = 'contained'
 
 if g:main_syntax is# 'dart'
   unlet g:main_syntax


### PR DESCRIPTION
Fixes violations of the Google vimscipt style guide.

- Use string matching operators that don't depend on user settings.
- Always put autocmd in an augroup.
- Use single quotes.
- Always prefix variables with their scope.