### PR TITLE
Add skipnl to match import URI and combinators

### DIFF
--- a/syntax/dart.vim
+++ b/syntax/dart.vim
@@ -40,9 +40,9 @@ syntax match   dartUserLabelRef   "\k\+" contained
 syntax region  dartLabelRegion   transparent matchgroup=dartLabel start="\<case\>" matchgroup=NONE end=":"
 syntax keyword dartLabel         default
 
-syntax match   dartLibrary       "^\(import\|export\)\>" nextgroup=dartUri skipwhite
-syntax region  dartUri           contained start=+r\=\z(["']\)+ end=+\z1+ nextgroup=dartCombinators skipwhite
-syntax region  dartCombinators   contained start="" end=";" contains=dartCombinator
+syntax match   dartLibrary       "^\(import\|export\)\>" nextgroup=dartUri skipwhite skipnl
+syntax region  dartUri           contained start=+r\=\z(["']\)+ end=+\z1+ nextgroup=dartCombinators skipwhite skipnl
+syntax region  dartCombinators   contained start="" end=";" contains=dartCombinator,dartComment,dartLineComment
 syntax keyword dartCombinator    contained show hide deferred as
 syntax match   dartLibrary       "^\(library\|part of\|part\)\>"
 


### PR DESCRIPTION
Fixes #103

Everything up to a `;` is part of a directive, including newlines. Add
`skipnl` so these newlines don't cause the combinators to highlight as
normal code.

Also add `dartComment` and `dartLineComment` to the `contains` for
`dartCombinators`.