### PR TITLE
Enable DartFmt Options with g:dartfmt_options

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,10 +79,8 @@ Enable Dart style guide syntax (like 2-space indentation) with
 
 Enable DartFmt execution on buffer save with `let g:dart_format_on_save = 1`
 
-Configure DartFmt Options with `let g:dartfmt_options`, for example, change
-line limit to 100 (default 80) and enable auto syntax fixes with
-`let g:dartfmt_options = "-l 100 --fix"`
-(see more options with `dartfmt -h`)
+Configure DartFmt options with `let g:dartfmt_options`
+(discover formatter options with `dartfmt -h`)
 
 ## FAQ
 

--- a/README.md
+++ b/README.md
@@ -79,6 +79,11 @@ Enable Dart style guide syntax (like 2-space indentation) with
 
 Enable DartFmt execution on buffer save with `let g:dart_format_on_save = 1`
 
+Configure DartFmt Options with `let g:dartfmt_options`, for example, change
+line limit to 100 (default 80) and enable auto syntax fixes with
+`let g:dartfmt_options = "-l 100 --fix"`
+(see more options with `dartfmt -h`)
+
 ## FAQ
 
 ### Why doesn't the plugin indent identically to `dartfmt`?

--- a/autoload/dart.vim
+++ b/autoload/dart.vim
@@ -56,11 +56,11 @@ function! dart#fmt(q_args) abort
 endfunction
 
 function! s:FindDartFmt() abort
-  if executable('dartfmt') | return 'dartfmt' | endif
+  if executable('dartfmt') | return 'dartfmt'.g:dartfmt_options | endif
   if executable('flutter')
     let l:flutter_cmd = resolve(exepath('flutter'))
     let l:bin = fnamemodify(l:flutter_cmd, ':h')
-    let l:dartfmt = l:bin.'/cache/dart-sdk/bin/dartfmt'
+    let l:dartfmt = l:bin.'/cache/dart-sdk/bin/dartfmt'.g:dartfmt_options
     if executable(l:dartfmt) | return l:dartfmt | endif
   endif
   call s:error('Cannot find a `dartfmt` command')

--- a/autoload/dart.vim
+++ b/autoload/dart.vim
@@ -65,7 +65,7 @@ function! s:FindDartFmt() abort
     let l:flutter_cmd = resolve(exepath('flutter'))
     let l:bin = fnamemodify(l:flutter_cmd, ':h')
     let l:dartfmt = l:bin.'/cache/dart-sdk/bin/dartfmt'
-    if executable(l:dartfmt) | return [l:dartfmt] | endif
+    if executable(l:dartfmt) | return l:dartfmt | endif
   endif
   call s:error('Cannot find a `dartfmt` command')
 endfunction

--- a/autoload/dart.vim
+++ b/autoload/dart.vim
@@ -56,11 +56,11 @@ function! dart#fmt(q_args) abort
 endfunction
 
 function! s:FindDartFmt() abort
-  if executable('dartfmt') | return 'dartfmt'.g:dartfmt_options | endif
+  if executable('dartfmt') | return 'dartfmt '.g:dartfmt_options | endif
   if executable('flutter')
     let l:flutter_cmd = resolve(exepath('flutter'))
     let l:bin = fnamemodify(l:flutter_cmd, ':h')
-    let l:dartfmt = l:bin.'/cache/dart-sdk/bin/dartfmt'.g:dartfmt_options
+    let l:dartfmt = l:bin.'/cache/dart-sdk/bin/dartfmt '.g:dartfmt_options
     if executable(l:dartfmt) | return l:dartfmt | endif
   endif
   call s:error('Cannot find a `dartfmt` command')

--- a/doc/dart.txt
+++ b/doc/dart.txt
@@ -52,7 +52,7 @@ match the Dart style guide - spaces only with an indent of 2. Also sets
 `formatoptions += t` to auto wrap text.
 
 Configure DartFmt options with `let g:dartfmt_options`, for example, enable
-auto syntax fixes with `let g:dartfmt_options = "--fix"`
+auto syntax fixes with `let g:dartfmt_options = ['--fix']`
 (discover formatter options with `dartfmt -h`)
 
 

--- a/doc/dart.txt
+++ b/doc/dart.txt
@@ -51,6 +51,11 @@ Set to any value (set to `2` by convention) to set tab and width behavior to
 match the Dart style guide - spaces only with an indent of 2. Also sets
 `formatoptions += t` to auto wrap text.
 
+Configure DartFmt options with `let g:dartfmt_options`, for example, enable
+auto syntax fixes with `let g:dartfmt_options = "--fix"`
+(discover formatter options with `dartfmt -h`)
+
+
 SYNTAX HIGHLIGHTING                              *dart-syntax*
 
 This plugin uses narrow highlight groups to allow selectively disabling the

--- a/plugin/dart.vim
+++ b/plugin/dart.vim
@@ -10,14 +10,14 @@ set cpo&vim
 function! s:FormatOnSave()
   " Dart code formatting on save
   if get(g:, 'dart_format_on_save', 0)
-    call dart#fmt('')
+    call dart#fmt()
   endif
 endfunction
 
 augroup dart-vim-plugin
   autocmd!
   autocmd BufWritePre *.dart call s:FormatOnSave()
-  autocmd FileType dart command! -buffer -nargs=? DartFmt       call dart#fmt(<q-args>)
+  autocmd FileType dart command! -buffer -nargs=? DartFmt       call dart#fmt(<f-args>)
   autocmd FileType dart command! -buffer DartToggleFormatOnSave call dart#ToggleFormatOnSave()
   autocmd FileType dart command! -buffer -nargs=? Dart2Js       call dart#tojs(<q-args>)
   autocmd FileType dart command! -buffer -nargs=? DartAnalyzer  call dart#analyzer(<q-args>)


### PR DESCRIPTION
With this PR, users will be able to configure DartFmt options with `g:dartfmt_options`. They can change the default line limit from 80 to any number they prefer. They can also make `dartfmt` fix issues such as optional `new` keywords.
```
$ dartfmt -h
...
Non-whitespace fixes (off by default):
    --fix                              Apply all style fixes.
    --fix-doc-comments                 Use triple slash for documentation comments.
    --fix-function-typedefs            Use new syntax for function type typedefs.
    --fix-named-default-separator      Use "=" as the separator before named parameter default values.
    --fix-optional-const               Remove "const" keyword inside constant context.
    --fix-optional-new                 Remove "new" keyword.
    --fix-single-cascade-statements    Remove unnecessary single cascades from expression statements.

Other options:
-l, --line-length                      Wrap lines longer than this.
                                       (defaults to "80")
-i, --indent                           Spaces of leading indentation.
                                       (defaults to "0")
...
```