### PR TITLE
Fix function and usertype matching

### DIFF
--- a/syntax/dart.vim
+++ b/syntax/dart.vim
@@ -52,10 +52,10 @@ syntax match   dartMetadata      "@\([_$a-zA-Z][_$a-zA-Z0-9]*\.\)*[_$a-zA-Z][_$a
 syntax match   dartNumber        "\<\d\+\(\.\d\+\)\=\>"
 
 " User Types
-syntax match   dartUserType      "\<_\?\u[[:alnum:]_\$]*\>"
+syntax match   dartUserType      "\<[_$]*\u[a-zA-Z0-9_$]*\>"
 
 " Function highlighting
-syntax match   dartFunction      "\zs\<\(_\?\l[[:alnum:]_\$]*\)\>*\s*\ze("
+syntax match   dartFunction      "\zs\<\([_$]*[a-z][a-zA-Z0-9_$]*\)\ze\(<\|(\|\s\+=>\)"
 
 " SDK libraries
 syntax keyword dartSdkClass     BidirectionalIterator Comparable DateTime


### PR DESCRIPTION
I translated the regex used by the VsCode dart plugin for the function match which fixes dart-lang#105

Also fixed an issue where you where only allowed to have a single underscore and no dollar sign before the first uppercase letter of a user type or before the first lowercase letter of a function