### PR TITLE
feat: Drop `DartAnalyze` and `Dart2Js`

### DIFF
--- a/autoload/dart.vim
+++ b/autoload/dart.vim
@@ -86,18 +86,6 @@ function! s:FindDartFmt() abort
   return []
 endfunction
 
-function! dart#analyzer(q_args) abort
-  call s:error('DartAnalyzer support has been removed. '.
-      \'If this broke your workflow please comment on '.
-      \'https://github.com/dart-lang/dart-vim-plugin/issues/89')
-endfunction
-
-function! dart#tojs(q_args) abort
-  call s:error('Dart2JS support has been removed. '.
-      \'If this broke your workflow please comment on '.
-      \'https://github.com/dart-lang/dart-vim-plugin/issues/89')
-endfunction
-
 " Finds the path to `uri`.
 "
 " If the file is a package: uri, looks for a .packages file to resolve the path.

--- a/doc/dart.txt
+++ b/doc/dart.txt
@@ -16,12 +16,6 @@ COMMANDS                                        *dart-commands*
 
 These commands are available in buffers with the dart filetype.
 
-                                                *:Dart2Js*
-Runs dart2js to compile the current file. Takes the same arguments as the
-dart2js binary and always passes the path to the current file as the last
-argument.
-If there are any errors they will be shown in the quickfix window.
-
                                                 *:DartFmt*
 Runs `dart format` and passes the current buffer content through stdin. If the
 format is successful replaces the current buffer content with the formatted
@@ -30,12 +24,6 @@ This command does not use the file content on disk so it is safe to run with
 unwritten changes.
 Options may be passed to `dart format` by setting |g:dartfmt_options| or passing
 arguments to the `:DartFmt` command.
-
-                                                *:DartAnalyzer*
-Runs dartanalyzer to analyze the current file. Takes the same arguments as the
-dartanalyzer binary and always passes the path to the current file as the last
-argument.
-If there are any errors they will be shown in the quickfix window.
 
 CONFIGURATION                                   *dart-configure*
 

--- a/plugin/dart.vim
+++ b/plugin/dart.vim
@@ -19,8 +19,6 @@ augroup dart-vim-plugin
   autocmd BufWritePre *.dart call s:FormatOnSave()
   autocmd FileType dart command! -buffer -nargs=? DartFmt       call dart#fmt(<f-args>)
   autocmd FileType dart command! -buffer DartToggleFormatOnSave call dart#ToggleFormatOnSave()
-  autocmd FileType dart command! -buffer -nargs=? Dart2Js       call dart#tojs(<q-args>)
-  autocmd FileType dart command! -buffer -nargs=? DartAnalyzer  call dart#analyzer(<q-args>)
   autocmd Filetype dart call dart#setModifiable()
 augroup END
 


### PR DESCRIPTION
Commands are deprecated for quite some time now.
I would like to have `DartAnalyze` working but viml is not my friend.

_I have my own version of `DartAnalyze` but written for neovim in lua._