### PR TITLE
Drop DartAnalyzer and Dart2JS command stubs

### DIFF
--- a/autoload/dart.vim
+++ b/autoload/dart.vim
@@ -86,18 +86,6 @@ function! s:FindDartFmt() abort
   return []
 endfunction
 
-function! dart#analyzer(q_args) abort
-  call s:error('DartAnalyzer support has been removed. '.
-      \'If this broke your workflow please comment on '.
-      \'https://github.com/dart-lang/dart-vim-plugin/issues/89')
-endfunction
-
-function! dart#tojs(q_args) abort
-  call s:error('Dart2JS support has been removed. '.
-      \'If this broke your workflow please comment on '.
-      \'https://github.com/dart-lang/dart-vim-plugin/issues/89')
-endfunction
-
 " Finds the path to `uri`.
 "
 " If the file is a package: uri, looks for a .packages file to resolve the path.

--- a/plugin/dart.vim
+++ b/plugin/dart.vim
@@ -19,8 +19,6 @@ augroup dart-vim-plugin
   autocmd BufWritePre *.dart call s:FormatOnSave()
   autocmd FileType dart command! -buffer -nargs=? DartFmt       call dart#fmt(<f-args>)
   autocmd FileType dart command! -buffer DartToggleFormatOnSave call dart#ToggleFormatOnSave()
-  autocmd FileType dart command! -buffer -nargs=? Dart2Js       call dart#tojs(<q-args>)
-  autocmd FileType dart command! -buffer -nargs=? DartAnalyzer  call dart#analyzer(<q-args>)
   autocmd Filetype dart call dart#setModifiable()
 augroup END
 


### PR DESCRIPTION
The implementations of these commands were dropped 2 years ago and we
left in stubs to avoid confusion for users still trying trying to use
them. We have not had complains and it's unlikely these stubs are
invoked anymore.