### PR TITLE
fix(indent): align indenting with `dart format`

### DIFF
--- a/indent/dart.vim
+++ b/indent/dart.vim
@@ -4,7 +4,7 @@ endif
 let b:did_indent = 1
 
 setlocal cindent
-setlocal cinoptions+=j1,J1,(2s,u2s,U1,m1,+2s
+setlocal cinoptions+=j1,J1,(2,U1,m1,+2s
 
 setlocal indentexpr=DartIndent()
 


### PR DESCRIPTION
Historically `dartfmt` used `4` spaces for the continuation after a parenthesis. Now `dart format` uses `2`.

*NOTE* I'm not 100% on these settings, as I only glanced through the `cinoptions` doc to see what was setting it to 2 * `shiftwidth`, but they appear to be working for some of the trivial examples I've tried and then compared to `dart format`.

Fixes: #114