### PR TITLE
Add g:dart_trailing_comma_indent

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,16 +84,17 @@ Configure DartFmt options with `let g:dartfmt_options`
 
 ## FAQ
 
-### Why doesn't the plugin indent identically to `dartfmt`?
+### Why doesn't the plugin indent identically to `dart format`?
 
 The indentation capabilities within vim are limited and it's not easy to fully
-express the indentation behavior of `dartfmt`. The major area where this plugin
-differs from `dartfmt` is indentation of function arguments when using a
-trailing comma in the argument list. When using a trailing comma (as is common
-in flutter widget code) `dartfmt` uses 2 space indent for argument parameters.
-In all other indentation following an open parenthesis (argument lists without a
-trailing comma, multi-line assert statements, etc) `dartfmt` uses 4 space
-indent. This plugin uses 4 space indent to match the most cases.
+express the indentation behavior of `dart format`. The major area where this
+plugin differs from `dart format` is indentation of function arguments when
+using a trailing comma in the argument list. When using a trailing comma (as is
+common in flutter widget code) `dart format` uses 2 space indent for argument
+parameters. In all other indentation following an open parenthesis (argument
+lists without a trailing comma, multi-line assert statements, etc) `dart format`
+uses 4 space indent. This plugin uses 4 space indent indent by default. To use 2
+space indent by default, `let g:dart_trailing_comma_indent = v:true`.
 
 
 ### How do I configure an LSP plugin to start the analysis server?

--- a/doc/dart.txt
+++ b/doc/dart.txt
@@ -50,6 +50,11 @@ Set to any value (set to `2` by convention) to set tab and width behavior to
 match the Dart style guide - spaces only with an indent of 2. Also sets
 `formatoptions += t` to auto wrap text.
 
+                                                *g:dart_trailing_comma_indent*
+Set to `v:true` to indent argument lists by the shiftwidth (2 spaces) instead of
+double that. This matches the indentation produced by `dart format` when the
+argument list uses a trailing comma.
+
                                                 *g:dartfmt_options*
 Configure DartFmt options with `let g:dartfmt_options`, for example, enable
 auto syntax fixes with `let g:dartfmt_options = ['--fix']`

--- a/indent/dart.vim
+++ b/indent/dart.vim
@@ -5,6 +5,11 @@ let b:did_indent = 1
 
 setlocal cindent
 setlocal cinoptions+=j1,J1,(2s,u2s,U1,m1,+2s
+if get(g: 'dart_trailing_comma_indent', v:false)
+  setlocal cinoptions+=(2s,u2s
+else
+  setlocal cinoptions+=(s,us
+endif
 
 setlocal indentexpr=DartIndent()
 

--- a/indent/dart.vim
+++ b/indent/dart.vim
@@ -4,8 +4,8 @@ endif
 let b:did_indent = 1
 
 setlocal cindent
-setlocal cinoptions+=j1,J1,(2s,u2s,U1,m1,+2s
-if get(g: 'dart_trailing_comma_indent', v:false)
+setlocal cinoptions+=j1,J1,U1,m1,+2s
+if get(g:, 'dart_trailing_comma_indent', v:false)
   setlocal cinoptions+=(2s,u2s
 else
   setlocal cinoptions+=(s,us


### PR DESCRIPTION
Closes #114

We've gotten a few requests to change the default indentation of
argument lists since it's so common for flutter authors to use frequent
trailing commas and see the different indentation behavior after
formatting. Add a configuration option so users who mostly have trailing
commas in argument lists can have their more common indentation while
typing as well.