### PR TITLE
Add missing class modifier keywords

### DIFF
--- a/syntax/dart.vim
+++ b/syntax/dart.vim
@@ -28,7 +28,8 @@ syntax keyword dartOperator       new is as in
 syntax match   dartOperator       "+=\=\|-=\=\|*=\=\|/=\=\|%=\=\|\~/=\=\|<<=\=\|>>=\=\|[<>]=\=\|===\=\|\!==\=\|&=\=\|\^=\=\||=\=\|||\|&&\|\[\]=\=\|=>\|!\|\~\|?\|:"
 syntax keyword dartCoreType       void var dynamic
 syntax keyword dartStatement      return
-syntax keyword dartStorageClass   static abstract final const factory late base interface sealed macro
+syntax keyword dartStorageClass   static abstract final const factory late base
+    \ interface sealed macro
 syntax keyword dartExceptions     throw rethrow try on catch finally
 syntax keyword dartAssert         assert
 syntax keyword dartClassDecl      extends with implements

--- a/syntax/dart.vim
+++ b/syntax/dart.vim
@@ -28,7 +28,7 @@ syntax keyword dartOperator       new is as in
 syntax match   dartOperator       "+=\=\|-=\=\|*=\=\|/=\=\|%=\=\|\~/=\=\|<<=\=\|>>=\=\|[<>]=\=\|===\=\|\!==\=\|&=\=\|\^=\=\||=\=\|||\|&&\|\[\]=\=\|=>\|!\|\~\|?\|:"
 syntax keyword dartCoreType       void var dynamic
 syntax keyword dartStatement      return
-syntax keyword dartStorageClass   static abstract final const factory late
+syntax keyword dartStorageClass   static abstract final const factory late base interface sealed macro
 syntax keyword dartExceptions     throw rethrow try on catch finally
 syntax keyword dartAssert         assert
 syntax keyword dartClassDecl      extends with implements


### PR DESCRIPTION
Missing highlights for classes.
https://github.com/dart-lang/dart-syntax-highlight/blob/master/test/test_files/classes.dart

I'm not sure if `dartStorageClass` is the correct group for these keywords.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
