### PR TITLE
Add support for overriding dart format command

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,8 @@ Enable Dart style guide syntax (like 2-space indentation) with
 Enable DartFmt execution on buffer save with `let g:dart_format_on_save = v:true`
 
 Configure DartFmt options with `let g:dartfmt_options`
-(discover formatter options with `dartfmt -h`)
+(discover formatter options with `dartfmt -h`). Override the default formatting
+command with `g:dartfmt_command`.
 
 ## FAQ
 

--- a/README.md
+++ b/README.md
@@ -50,9 +50,9 @@ Enable Dart style guide syntax (like 2-space indentation) with
 
 Enable DartFmt execution on buffer save with `let g:dart_format_on_save = v:true`
 
-Configure DartFmt options with `let g:dartfmt_options`
-(discover formatter options with `dartfmt -h`). Override the default formatting
-command with `g:dartfmt_command`.
+Configure DartFmt options with `g:dartfmt_options`
+(discover formatter options with `dart format -h`). Override the default
+formatting command with `g:dartfmt_command`.
 
 ## FAQ
 

--- a/autoload/dart.vim
+++ b/autoload/dart.vim
@@ -60,29 +60,15 @@ function! dart#fmt(...) abort
 endfunction
 
 function! s:FindDartFmt() abort
+  if exists('g:dartfmt_command')
+    return type(g:dart_format_command) == v:t_list
+        \ ? g:dart_format_command
+        \ : [g:dart_format_command]
+  endif
   if executable('dart')
-    let l:version_text = system('dart --version')
-    let l:match = matchlist(l:version_text,
-        \ '\vDart SDK version: (\d+)\.(\d+)\.\d+.*')
-    if empty(l:match)
-      call s:error('Unable to determine dart version')
-      return []
-    endif
-    let l:major = l:match[1]
-    let l:minor = l:match[2]
-    if l:major > 2 || l:major == 2 && l:minor >= 14
-      return ['dart', 'format']
-    endif
+    return ['dart', 'format']
   endif
-  " Legacy fallback for Dart SDK pre 2.14
-  if executable('dartfmt') | return ['dartfmt'] | endif
-  if executable('flutter')
-    let l:flutter_cmd = resolve(exepath('flutter'))
-    let l:bin = fnamemodify(l:flutter_cmd, ':h')
-    let l:dartfmt = l:bin.'/cache/dart-sdk/bin/dartfmt'
-    if executable(l:dartfmt) | return [l:dartfmt] | endif
-  endif
-  call s:error('Cannot find a `dartfmt` command')
+  call s:error('Cannot find a `dart` command')
   return []
 endfunction
 


### PR DESCRIPTION
Add an option to override the command to enable easier testing against
custom formatter implementations.

Drop support for legacy SDKs with `dartfmt` as a separate command. These
SDKs are likely unused with this plugin anymore, and if they are the
same config that enables testing can be a workaround.
