### PR TITLE
Fix dartfmt_command override

### DIFF
--- a/autoload/dart.vim
+++ b/autoload/dart.vim
@@ -82,9 +82,9 @@ endfunction
 
 function! s:FindDartFmt() abort
   if exists('g:dartfmt_command')
-    return type(g:dart_format_command) == v:t_list
-        \ ? g:dart_format_command
-        \ : [g:dart_format_command]
+    return type(g:dartfmt_command) == v:t_list
+        \ ? g:dartfmt_command
+        \ : [g:dartfmt_command]
   endif
   if executable('dart')
     return ['dart', 'format']

--- a/doc/dart.txt
+++ b/doc/dart.txt
@@ -60,6 +60,10 @@ Configure DartFmt options with `let g:dartfmt_options`, for example, enable
 auto syntax fixes with `let g:dartfmt_options = ['--fix']`
 (discover formatter options with `dart format -h`)
 
+                                                *g:dartfmt_command*
+Override the command used for formatting. Defaults to `['dart', 'format']`.
+May be a String or a List of Strings.
+
 
 SYNTAX HIGHLIGHTING                              *dart-syntax*
 


### PR DESCRIPTION
I apparently didn't test it manually after an incorrect find/replace.
Fix the variable that is read to match the one that is known to exist.

Add mention of the config in `doc/dart.txt`.
