### PR TITLE
Use buffer IO directly to format process

### DIFF
--- a/autoload/dart.vim
+++ b/autoload/dart.vim
@@ -37,6 +37,8 @@ function! dart#fmt(...) abort
   let l:stdout_data = []
   let l:stderr_data = []
   let l:options = {
+      \ 'in_io': 'buffer',
+      \ 'in_buf': bufnr('%'),
       \ 'out_cb': { ch, msg -> add(l:stdout_data, msg) },
       \ 'err_cb': { ch, msg -> add(l:stderr_data, msg) },
       \ 'close_cb': { ch ->
@@ -45,8 +47,6 @@ function! dart#fmt(...) abort
     let options['noblock'] = v:true
   endif
   let l:job = job_start(l:cmd, l:options)
-  call ch_sendraw(job_getchannel(l:job), join(l:buffer_content, "\n"))
-  call ch_close_in(job_getchannel(l:job))
 endfunction
 
 function! s:formatResult(stdout, stderr, buffer_content) abort

--- a/autoload/dart.vim
+++ b/autoload/dart.vim
@@ -28,7 +28,6 @@ endfunction
 function! dart#fmt(...) abort
   let l:dartfmt = s:FindDartFmt()
   if empty(l:dartfmt) | return | endif
-  let buffer_content = getline(1, '$')
   let l:cmd = extend(l:dartfmt, ['--stdin-name', expand('%')])
   if exists('g:dartfmt_options')
     call extend(l:cmd, g:dartfmt_options)
@@ -42,19 +41,31 @@ function! dart#fmt(...) abort
       \ 'out_cb': { ch, msg -> add(l:stdout_data, msg) },
       \ 'err_cb': { ch, msg -> add(l:stderr_data, msg) },
       \ 'close_cb': { ch ->
-      \    s:formatResult(l:stdout_data, l:stderr_data, l:buffer_content)} }
+      \    s:formatResult(l:stdout_data, l:stderr_data)} }
   if has('patch-8.1.350')
     let options['noblock'] = v:true
   endif
   let l:job = job_start(l:cmd, l:options)
 endfunction
 
-function! s:formatResult(stdout, stderr, buffer_content) abort
-  if a:buffer_content == a:stdout
-    call s:clearQfList('dartfmt')
-    return
-  endif
+function! s:formatResult(stdout, stderr) abort
   if !empty(a:stdout)
+    let l:is_equal = v:false
+    if line('$') == len(a:stdout)
+      let l:is_equal = v:true
+      for l:i in range(1, line('$'))
+        if getline(l:i) !=# a:stdout[l:i - 1]
+          let l:is_equal = v:false
+          break
+        endif
+      endfor
+    endif
+
+    if l:is_equal
+      call s:clearQfList('dartfmt')
+      return
+    endif
+
     let win_view = winsaveview()
     silent keepjumps call setline(1, a:stdout)
     if line('$') > len(a:stdout)


### PR DESCRIPTION
The pattern of creating a single large vimscript string and sending to
the job does not work for very large Dart files. Use `'in_io': 'buffer'`
instead.
